### PR TITLE
Schlechter fix für XP_ExterneReferenz

### DIFF
--- a/XPTools.py
+++ b/XPTools.py
@@ -568,11 +568,25 @@ class XPTools():
                 newFeaturesetId(fid)
 
             provider = layer.dataProvider()
+            
+            
             fields = layer.fields()
             newFeature.initAttributes(fields.count())
 
             for i in range(fields.count()):
-                newFeature.setAttribute(i,provider.defaultValue(i))
+                ## bad fix for bug in Default retrieval from postgres 
+                ## (defaultValue won't give 9999 integer for e.g. XP_ExterneReferenz default value, 
+                ## but defaultValueClause does. Though defaultValueClause will return '' 
+                ## where None/NULL is correct)
+                ## REALLY DON'T KNOW IF THERE IS SOMEWHERE A CORRECT DEFAULT EMPTY STRING, WHICH 
+                ## SHOULDN'T BE FIXED...
+                if provider.defaultValueClause(i)=='':
+                    newFeature.setAttribute(i,provider.defaultValue(i))
+                else:
+                    newFeature.setAttribute(i,provider.defaultValueClause(i))
+                ## end fix
+                ## old:
+                ## newFeature.setAttribute(i,provider.defaultValue(i))
 
             return newFeature
         else:


### PR DESCRIPTION
Um herauszufinden ob ich selbst XP_Hoehenangaben (#15) implementieren kann, musste ich erstmal herausfinden wie XP_ExterneReferenz implementiert ist und bin dabei auf einen Bug gestoßen: Die Default Values konnten von QGIS nicht korrekt ermittelt und dementsprechend nicht in die Postgres-Datenbank eingetragen werden.

Der default Value 9999 für das Feld typ in XP_SpezExterneReferenz wurde durch provider.defaultValue(1) als '' ermittelt.

Hier ein schnelle Flickschusterei, wahrscheinlich sollte lieber das DefaultValue-Retrieval genauer angeguckt werden...
Zukünftig wird evtl. das hier relevant: https://github.com/qgis/QGIS-Enhancement-Proposals/issues/247