### PR TITLE
Hoehenmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ tools/*.py
 images/
 Ui*.py
 xplanung.zip
+schema/*
+__pycache__/*
+.settings
+.pydevproject
+.project
+.gitignore

--- a/Ui_Hoehenmanager.ui
+++ b/Ui_Hoehenmanager.ui
@@ -42,6 +42,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QgsMapCanvas" name="canvas" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QListWidget" name="hoehen">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
@@ -51,16 +61,6 @@
      </property>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QgsMapCanvas" name="canvas" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>250</height>
-      </size>
      </property>
     </widget>
    </item>

--- a/Ui_Hoehenmanager.ui
+++ b/Ui_Hoehenmanager.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Hoehenmananger</class>
+ <widget class="QDialog" name="Hoehenmananger">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Hoehenmanager</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="txlFilter">
+       <property name="toolTip">
+        <string>Filterbegriff eingeben</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnFilter">
+       <property name="toolTip">
+        <string>Nur dem Filter entsprechende Einträge anzeigen</string>
+       </property>
+       <property name="text">
+        <string>Filtern</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListWidget" name="hoehen">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+     <property name="toolTip">
+      <string>Rechtsklick zum Bearbeiten</string>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Hoehenmananger</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Hoehenmananger</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Ui_Hoehenmanager.ui
+++ b/Ui_Hoehenmanager.ui
@@ -42,6 +42,19 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Bitte wählen Sie ein Flächenobjekt aus, um die dazugehörige Höhe zu bearbeiten bzw. ein neues Höhenobjekt anzulegen.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QgsMapCanvas" name="canvas" native="true">
      <property name="minimumSize">
       <size>

--- a/Ui_Hoehenmanager.ui
+++ b/Ui_Hoehenmanager.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>397</width>
+    <height>462</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,6 +55,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QgsMapCanvas" name="canvas" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -66,6 +76,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsMapCanvas</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/XPImport.py
+++ b/XPImport.py
@@ -68,7 +68,7 @@ class XPImporter(object):
             commands = ['ogr2ogr'] + arguments
 
         fused_command = ' '.join([str(c) for c in commands])
-
+        self.tools.showWarning(fused_command) 
         try:
             proc = subprocess.check_output(
                 fused_command,

--- a/XPTools.py
+++ b/XPTools.py
@@ -267,8 +267,8 @@ class XPTools():
 
     def getMaxGid(self, db, schemaName, tableName, pkFieldName = "gid"):
         retValue = -9999
-        sel = "SELECT " + pkFieldName + " FROM \"" + schemaName + "\".\"" + tableName + \
-            "\" ORDER BY 1 DESC LIMIT 1;"
+        sel = 'SELECT "' + pkFieldName + '" FROM \"' + schemaName + '"."' + tableName + \
+            '" ORDER BY 1 DESC LIMIT 1;'
 
         query = QtSql.QSqlQuery(db)
         query.prepare(sel)

--- a/XPTools.py
+++ b/XPTools.py
@@ -565,7 +565,7 @@ class XPTools():
             newFeature = QgsVectorLayerUtils.createFeature(layer)
 
             if fid:
-                newFeaturesetId(fid)
+                newFeaturesetId(fid) #is this defined?
 
             provider = layer.dataProvider()
             fields = layer.fields()

--- a/XPTools.py
+++ b/XPTools.py
@@ -31,6 +31,10 @@ from qgis.gui import *
 from .XPlanDialog import BereichsauswahlDialog
 from .XPlanDialog import StilauswahlDialog
 
+from traceback import format_stack
+import inspect
+from pprint import pformat
+
 class XPTools():
     def __init__(self, iface, standardName, simpleStyleName):
         self.iface = iface
@@ -649,9 +653,15 @@ class XPTools():
         #self.log(msg, "warn")
 
     def showError(self, msg, title = "XPlanung"):
+        t_ = [
+            x[0].f_locals for x in inspect.trace()
+        ]
+        if len(t_) >=10:
+            t_ = ['...'] + t_[-10:]
         self.iface.messageBar().pushMessage(title,
-            msg, level=Qgis.Critical, duration = 10)
-        self.log(msg, "error")
+            msg + " (more in log)", level=Qgis.Critical, duration = 10)
+        self.log(msg +'\n' + str(format_stack()), "error")
+        self.debug( pformat( t_ ) )
 
     def noStyleWarning(self, layer):
         self.showWarning(u"Für den Layer " + layer.name() + u" sind keine Stile gespeichert")

--- a/XPTools.py
+++ b/XPTools.py
@@ -635,6 +635,27 @@ class XPTools():
     def noActiveLayerWarning(self):
         self.showWarning(u"Kein aktiver Layer")
 
+    def debug(self,  msg, stacksize=0):
+        t_ = [
+            x[0].f_locals for x in inspect.trace()
+        ]
+        if stacksize==0:
+            self.log("Debug" + "\n" + msg)
+        elif len(t_) >=stacksize:
+            t_ = ['...'] + t_[-1*stacksize:]
+            self.log("Debug" + "\n" + msg + ' | ' + pformat( t_ ))
+        else:
+            self.log("Debug" + "\n" + msg + ' | ' + pformat( t_ ))
+
+    def log(self, msg, type = 'info'):
+        if type == 'info':
+            msgType = Qgis.Info
+        if type == 'warn':
+            msgType = Qgis.Warning
+        if type == 'error':
+            msgType = Qgis.Critical
+        QgsMessageLog.logMessage(msg, "XPlanung", msgType)
+        
     def showQueryError(self, query):
         self.showError(
             "%(error)s" % {"error": query.lastError().text()}, "DB-Fehler")
@@ -653,30 +674,13 @@ class XPTools():
         #self.log(msg, "warn")
 
     def showError(self, msg, title = "XPlanung"):
-        t_ = [
-            x[0].f_locals for x in inspect.trace()
-        ]
-        if len(t_) >=10:
-            t_ = ['...'] + t_[-10:]
         self.iface.messageBar().pushMessage(title,
             msg + " (more in log)", level=Qgis.Critical, duration = 10)
         self.log(msg +'\n' + str(format_stack()), "error")
-        self.debug( pformat( t_ ) )
+        self.debug(msg, 2)
 
     def noStyleWarning(self, layer):
         self.showWarning(u"Für den Layer " + layer.name() + u" sind keine Stile gespeichert")
-
-    def debug(self,  msg):
-        self.log("Debug" + "\n" + msg)
-
-    def log(self, msg, type = 'info'):
-        if type == 'info':
-            msgType = Qgis.Info
-        if type == 'warn':
-            msgType = Qgis.Warning
-        if type == 'error':
-            msgType = Qgis.Critical
-        QgsMessageLog.logMessage(msg, "XPlanung", msgType)
 
     def getAuthUserNamePassword(self, authcfg):
         username = None

--- a/XPTools.py
+++ b/XPTools.py
@@ -568,11 +568,25 @@ class XPTools():
                 newFeaturesetId(fid)
 
             provider = layer.dataProvider()
+            
+            
             fields = layer.fields()
             newFeature.initAttributes(fields.count())
 
             for i in range(fields.count()):
-                newFeature.setAttribute(i,provider.defaultValue(i))
+                ## bad fix for bug in Default retrieval from postgres 
+                ## (defaultValue won't give 9999 integer for e.g. XP_ExterneReferenz default value, 
+                ## but defaultValueClause does. Though defaultValueClause will return '' 
+                ## where None/NULL is correct)
+                ## REALLY DON'T KNOW IF THERE IS SOMEWHERE A CORRECT DEFAULT EMPTY STRING, WHICH 
+                ## SHOULDN'T BE FIXED...
+                if provider.defaultValueClause(i)=='':
+                    newFeature.setAttribute(i,provider.defaultValue(i))
+                else:
+                    newFeature.setAttribute(i,provider.defaultValueClause(i))
+                ## end fix
+                ## old:
+                ## newFeature.setAttribute(i,provider.defaultValue(i))
 
             return newFeature
         else:

--- a/XPTools.py
+++ b/XPTools.py
@@ -568,8 +568,6 @@ class XPTools():
                 newFeaturesetId(fid)
 
             provider = layer.dataProvider()
-            
-            
             fields = layer.fields()
             newFeature.initAttributes(fields.count())
 

--- a/XPlan.py
+++ b/XPlan.py
@@ -27,10 +27,8 @@ from builtins import object
 from qgis.PyQt import QtCore, QtWidgets, QtSql
 from qgis.core import *
 from qgis.gui import *
-# import importlib
 
 try:
-    ## importlib.reload(DataDrivenInputMask)
     from DataDrivenInputMask.ddattribute import DdTable
 except:
     pass
@@ -910,16 +908,21 @@ class XPlan(object):
                 schemaName, tableName, withOid = False,
                 withComment = False)
 
-            isView = ddTable == None
+            isView = ddTable is None
 
             if isView:
                 ddTable = DdTable(schemaName = schemaName, tableName = tableName)
 
             if self.app.xpManager.existsInDb(ddTable, self.db):
-                thisLayer = self.app.xpManager.loadPostGISLayer(self.db,
-                    ddTable, displayName = displayName,
-                    geomColumn = geomColumn, keyColumn = "gid",
-                    whereClause = filter,  intoDdGroup = False)
+                thisLayer = self.app.xpManager.loadPostGISLayer(
+                    self.db,
+                    ddTable, 
+                    displayName = displayName,
+                    geomColumn = geomColumn, 
+                    keyColumn = "gid",
+                    whereClause = filter,  
+                    intoDdGroup = False
+                )
 
         return [thisLayer, isView]
 
@@ -1129,7 +1132,7 @@ class XPlan(object):
                     self.tools.useStyle(layer, stil)
 
     def getLayerForTable(self, schemaName, tableName,
-        geomColumn = None, showMsg = True):
+        geomColumn = None, showMsg = True, filterOnNew=""):
         '''Den Layer schemaName.tableName finden bzw. laden.
         Wenn geomColumn == None wird geoemtrielos geladen'''
 
@@ -1143,7 +1146,7 @@ class XPlan(object):
 
             if layer == None:
                 layer = self.loadTable(schemaName, tableName,
-                    geomColumn = geomColumn)[0]
+                    geomColumn = geomColumn, filter=filterOnNew)[0]
 
                 if layer == None:
                     if showMsg:

--- a/XPlan.py
+++ b/XPlan.py
@@ -27,8 +27,10 @@ from builtins import object
 from qgis.PyQt import QtCore, QtWidgets, QtSql
 from qgis.core import *
 from qgis.gui import *
+# import importlib
 
 try:
+    ## importlib.reload(DataDrivenInputMask)
     from DataDrivenInputMask.ddattribute import DdTable
 except:
     pass
@@ -42,7 +44,7 @@ from .XPTools import XPTools
 from .XPImport import XPImporter
 from .XPlanDialog import XPlanungConf
 from .XPlanDialog import ChooseObjektart
-from .XPlanDialog import XPNutzungsschablone, BereichsmanagerDialog, ReferenzmanagerDialog, ImportDialog
+from .XPlanDialog import XPNutzungsschablone, BereichsmanagerDialog, ReferenzmanagerDialog, HoehenmanagerDialog, ImportDialog
 
 class XpError(object):
     '''General error'''
@@ -193,6 +195,8 @@ class XPlan(object):
         self.action24.triggered.connect(self.loadSO)
         self.action25 = QtWidgets.QAction(u"ExterneReferenzen bearbeiten", self.iface.mainWindow())
         self.action25.triggered.connect(self.referenzmanagerStarten)
+        self.action25b = QtWidgets.QAction(u"Hoehenangaben bearbeiten", self.iface.mainWindow())
+        self.action25b.triggered.connect(self.hoehenmanagerStarten)
         self.action26 = QtWidgets.QAction(u"räuml. Geltungsbereiche neu berechnen",
             self.iface.mainWindow())
         self.action26.triggered.connect(self.geltungsbereichBerechnen)
@@ -205,7 +209,7 @@ class XPlan(object):
         self.action30 = QtWidgets.QAction(u"Importieren", self.iface.mainWindow())
         self.action30.triggered.connect(self.importData)
 
-        self.xpMenu.addActions([self.action20, self.action25, self.action29,
+        self.xpMenu.addActions([self.action20, self.action25, self.action25b, self.action29,
             self.action6, self.action10, self.action30])
         self.bereichMenu.addActions([self.action3, self.action1, self.action4])
         self.bpMenu.addActions([self.action21, self.action26, self.action28])
@@ -706,6 +710,21 @@ class XPlan(object):
                 dlg.show()
                 dlg.exec_()
 
+    def hoehenmanagerStarten(self):
+        if self.db == None:
+            self.initialize(False)
+
+        if self.db != None:
+            refSchema = "XP_Sonstiges"
+            refTable = "XP_Hoehenangabe"
+            extRefLayer = self.getLayerForTable(refSchema, refTable)
+
+            if extRefLayer != None:
+                self.app.xpManager.moveLayerToGroup(extRefLayer, refSchema)
+                dlg = HoehenmanagerDialog(self, extRefLayer)
+                dlg.show()
+                dlg.exec_()
+                
     def onLayerDestroyed(self, layer):
         '''Slot, der aufgerufen wird wenn ein XP-Layer aus dem Projekt entfernt wird
         erst in QGIS3 wird das Layerobjekt übergeben'''

--- a/XPlan.py
+++ b/XPlan.py
@@ -716,7 +716,8 @@ class XPlan(object):
             refSchema = "XP_Sonstiges"
             refTable = "XP_Hoehenangabe"
             extRefLayer = self.getLayerForTable(refSchema, refTable)
-
+            # self.tools.debug(str(type(extRefLayer)))
+            
             if extRefLayer != None:
                 self.app.xpManager.moveLayerToGroup(extRefLayer, refSchema)
                 dlg = HoehenmanagerDialog(self, extRefLayer)

--- a/XPlan.py
+++ b/XPlan.py
@@ -1181,8 +1181,10 @@ class XPlan(object):
             withOid = False, withComment = False)
 
         if (not (ddTable is None)) or ignoreDD:
-            layer = self.findPostgresLayer(
-                self.db, ddTable, schemaName=schemaName, tableName=tableName)
+            layer = self.findPostgresLayer( #not using app.xpManager/ddmanager directly
+                self.db, 
+                ddTable, #if not None, following parameters are ignored
+                schemaName=schemaName, tableName=tableName)
             
             if layer is None:
                 layer = self.loadTable(
@@ -1200,8 +1202,9 @@ class XPlan(object):
                             self.iface)
                     return None
                 else:
-                    self.app.xpManager.createGroup(schemaName, False) #doesn't add group if already exists.
-                    self.app.xpManager.moveLayerToGroup(layer, schemaName)
+                    if (ddTable is None): #for views
+                        self.app.xpManager.createGroup(schemaName, False) #doesn't add group if already exists.
+                        self.app.xpManager.moveLayerToGroup(layer, schemaName)
                     return layer
             else:
                 return layer

--- a/XPlan.py
+++ b/XPlan.py
@@ -30,6 +30,7 @@ from qgis.gui import *
 
 try:
     from DataDrivenInputMask.ddattribute import DdTable
+    from DataDrivenInputMask.dderror import FatalError
 except:
     pass
 
@@ -908,22 +909,25 @@ class XPlan(object):
             ddTable = self.app.xpManager.createDdTable(self.db,
                 schemaName, tableName, withOid = False,
                 withComment = False)
-
-            isView = ddTable is None
+            
+            isView = ddTable is None #Why does this not hit on "BP_Basisobjekte.BP_Flaechenobjekte"?
 
             if isView:
                 ddTable = DdTable(schemaName = schemaName, tableName = tableName)
 
             if self.app.xpManager.existsInDb(ddTable, self.db):
-                thisLayer = self.app.xpManager.loadPostGISLayer(
-                    self.db,
-                    ddTable, 
-                    displayName = displayName,
-                    geomColumn = geomColumn, 
-                    keyColumn = "gid",
-                    whereClause = filter,  
-                    intoDdGroup = False
-                )
+                try:
+                    thisLayer = self.app.xpManager.loadPostGISLayer(
+                        self.db,
+                        ddTable, 
+                        displayName = displayName,
+                        geomColumn = geomColumn, 
+                        keyColumn = "gid",
+                        whereClause = filter,  
+                        intoDdGroup = False
+                    )
+                except FatalError as fa:
+                    raise fa
 
         return [thisLayer, isView]
 

--- a/XPlan.py
+++ b/XPlan.py
@@ -252,8 +252,8 @@ class XPlan(object):
         except:
             pass
 
-    def debug(self, msg):
-        self.tools.log("Debug" + "\n" + msg)
+    def debug(self, msg, stacksize=0):
+        self.tools.debug(msg, stacksize=stacksize)
 
     def loadLayerLayer(self):
         self.layerLayer = self.getLayerForTable("QGIS", "layer")


### PR DESCRIPTION
Hi

angesichts unseres Bedarfs Höhen zu editieren (#15), habe ich experimentiert um einen Höheneditor zu erfinden, basierend auf dem ExterneReferenzenEditor. Das dient hier primär als Info und ggf. als Vorlage für weitere Arbeiten, wahrscheinlich werde ich das nicht ultimativ bald fertig stellen können.

<strike>Hinzufügen neuer Werte funktioniert bislang nicht (da braucht es eine XP_Objekt-Referenz-ID, die in einem zwischengeschalteten Dialog noch ermittelt werden muss). Editieren sorgt für einen fatalen DB-Error in DataDrivenInput (wenn man aber den raise des FatalErrors in DDI deaktiviert, so öffnet sich ein schönes Edit-Fenster)</strike>

Work in Progress.
